### PR TITLE
10 feature dashboard pantalla de resumen f03

### DIFF
--- a/android-app/app/src/main/java/com/agentasker/MainActivity.kt
+++ b/android-app/app/src/main/java/com/agentasker/MainActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Dashboard
 import androidx.compose.material.icons.outlined.School
 import androidx.compose.material.icons.outlined.TaskAlt
 import androidx.compose.material3.Icon
@@ -30,6 +31,7 @@ import com.agentasker.core.navigation.Screen
 import com.agentasker.core.ui.theme.AgenTaskerTheme
 import com.agentasker.features.classroom.data.services.ClassroomAuthService
 import com.agentasker.features.classroom.presentation.screens.ClassroomScreen
+import com.agentasker.features.dashboard.presentation.screens.DashboardScreen
 import com.agentasker.features.login.presentation.screens.LoginScreen
 import com.agentasker.features.login.presentation.viewmodel.LoginViewModel
 import com.agentasker.features.tasks.presentation.screens.TaskScreen
@@ -63,7 +65,7 @@ fun AgentTaskerApp(classroomAuthService: ClassroomAuthService) {
     val loginUiState by loginViewModel.uiState.collectAsStateWithLifecycle()
 
     val startDestination = if (loginUiState.isAuthenticated) {
-        Screen.Tasks.route
+        Screen.Dashboard.route
     } else {
         Screen.Login.route
     }
@@ -76,9 +78,30 @@ fun AgentTaskerApp(classroomAuthService: ClassroomAuthService) {
             LoginScreen(
                 viewModel = loginViewModel,
                 onLoginSuccess = {
-                    navigatorWrapper.navigateToTasks(clearBackStack = true)
+                    navigatorWrapper.navigateToDashboard(clearBackStack = true)
                 }
             )
+        }
+
+        composable(Screen.Dashboard.route) {
+            MainScaffold(navController = navController, currentRoute = Screen.Dashboard.route) {
+                DashboardScreen(
+                    onNavigateToTasks = {
+                        navController.navigate(Screen.Tasks.route) {
+                            popUpTo(Screen.Dashboard.route) { saveState = true }
+                            launchSingleTop = true
+                            restoreState = true
+                        }
+                    },
+                    onNavigateToClassroom = {
+                        navController.navigate(Screen.Classroom.route) {
+                            popUpTo(Screen.Dashboard.route) { saveState = true }
+                            launchSingleTop = true
+                            restoreState = true
+                        }
+                    }
+                )
+            }
         }
 
         composable(Screen.Tasks.route) {
@@ -105,12 +128,26 @@ fun MainScaffold(
         bottomBar = {
             NavigationBar {
                 NavigationBarItem(
+                    selected = currentRoute == Screen.Dashboard.route,
+                    onClick = {
+                        if (currentRoute != Screen.Dashboard.route) {
+                            navController.navigate(Screen.Dashboard.route) {
+                                popUpTo(Screen.Dashboard.route) { inclusive = true }
+                                launchSingleTop = true
+                            }
+                        }
+                    },
+                    icon = { Icon(Icons.Outlined.Dashboard, contentDescription = "Dashboard") },
+                    label = { Text("Dashboard") }
+                )
+                NavigationBarItem(
                     selected = currentRoute == Screen.Tasks.route,
                     onClick = {
                         if (currentRoute != Screen.Tasks.route) {
                             navController.navigate(Screen.Tasks.route) {
-                                popUpTo(Screen.Tasks.route) { inclusive = true }
+                                popUpTo(Screen.Dashboard.route) { saveState = true }
                                 launchSingleTop = true
+                                restoreState = true
                             }
                         }
                     },
@@ -122,7 +159,7 @@ fun MainScaffold(
                     onClick = {
                         if (currentRoute != Screen.Classroom.route) {
                             navController.navigate(Screen.Classroom.route) {
-                                popUpTo(Screen.Tasks.route) { saveState = true }
+                                popUpTo(Screen.Dashboard.route) { saveState = true }
                                 launchSingleTop = true
                                 restoreState = true
                             }

--- a/android-app/app/src/main/java/com/agentasker/core/navigation/NavigatorWrapper.kt
+++ b/android-app/app/src/main/java/com/agentasker/core/navigation/NavigatorWrapper.kt
@@ -19,6 +19,16 @@ class NavigatorWrapper(private val navController: NavHostController) {
         }
     }
 
+    fun navigateToDashboard(clearBackStack: Boolean = false) {
+        if (clearBackStack) {
+            navController.navigate(Screen.Dashboard.route) {
+                popUpTo(0) { inclusive = true }
+            }
+        } else {
+            navController.navigate(Screen.Dashboard.route)
+        }
+    }
+
     fun navigateToTasks(clearBackStack: Boolean = false) {
         if (clearBackStack) {
             navController.navigate(Screen.Tasks.route) {

--- a/android-app/app/src/main/java/com/agentasker/core/navigation/Screen.kt
+++ b/android-app/app/src/main/java/com/agentasker/core/navigation/Screen.kt
@@ -2,6 +2,7 @@ package com.agentasker.core.navigation
 
 sealed class Screen(val route: String) {
     object Login : Screen("login")
+    object Dashboard : Screen("dashboard")
     object Tasks : Screen("tasks")
     object Classroom : Screen("classroom")
 }

--- a/android-app/app/src/main/java/com/agentasker/features/dashboard/presentation/components/DashboardCard.kt
+++ b/android-app/app/src/main/java/com/agentasker/features/dashboard/presentation/components/DashboardCard.kt
@@ -1,0 +1,60 @@
+package com.agentasker.features.dashboard.presentation.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun DashboardCard(
+    title: String,
+    icon: ImageVector,
+    iconTint: Color = MaterialTheme.colorScheme.primary,
+    modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null,
+    content: @Composable () -> Unit
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .then(if (onClick != null) Modifier.clickable { onClick() } else Modifier),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surface
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = iconTint,
+                    modifier = Modifier.size(24.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium
+                )
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            content()
+        }
+    }
+}

--- a/android-app/app/src/main/java/com/agentasker/features/dashboard/presentation/screens/DashboardScreen.kt
+++ b/android-app/app/src/main/java/com/agentasker/features/dashboard/presentation/screens/DashboardScreen.kt
@@ -1,0 +1,362 @@
+package com.agentasker.features.dashboard.presentation.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Assignment
+import androidx.compose.material.icons.outlined.CalendarToday
+import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.Flag
+import androidx.compose.material.icons.outlined.Pending
+import androidx.compose.material.icons.outlined.School
+import androidx.compose.material.icons.outlined.Schedule
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.agentasker.core.ui.components.LoadingState
+import com.agentasker.features.dashboard.presentation.components.DashboardCard
+import com.agentasker.features.dashboard.presentation.viewmodel.DashboardUiState
+import com.agentasker.features.dashboard.presentation.viewmodel.DashboardViewModel
+import com.agentasker.features.dashboard.presentation.viewmodel.UpcomingItem
+import java.time.format.DateTimeFormatter
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DashboardScreen(
+    viewModel: DashboardViewModel = hiltViewModel(),
+    onNavigateToTasks: () -> Unit = {},
+    onNavigateToClassroom: () -> Unit = {}
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            CenterAlignedTopAppBar(
+                title = { Text("Dashboard") }
+            )
+        }
+    ) { innerPadding ->
+        when (val state = uiState) {
+            is DashboardUiState.Loading -> {
+                LoadingState(modifier = Modifier.padding(innerPadding))
+            }
+            is DashboardUiState.Error -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = state.message,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+            }
+            is DashboardUiState.Success -> {
+                DashboardContent(
+                    state = state,
+                    onNavigateToTasks = onNavigateToTasks,
+                    onNavigateToClassroom = onNavigateToClassroom,
+                    modifier = Modifier.padding(innerPadding)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DashboardContent(
+    state: DashboardUiState.Success,
+    onNavigateToTasks: () -> Unit,
+    onNavigateToClassroom: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        item { Spacer(modifier = Modifier.height(4.dp)) }
+
+        // Resumen rápido
+        item {
+            SummarySection(
+                pendingCount = state.pendingCount,
+                completedCount = state.completedCount,
+                dueSoonCount = state.dueSoonCount,
+                onNavigateToTasks = onNavigateToTasks
+            )
+        }
+
+        // Próximas entregas
+        item {
+            DashboardCard(
+                title = "Próximas entregas",
+                icon = Icons.Outlined.CalendarToday,
+                iconTint = Color(0xFF1976D2)
+            ) {
+                if (state.upcomingDeadlines.isEmpty()) {
+                    Text(
+                        text = "No hay entregas próximas",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                } else {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        state.upcomingDeadlines.forEach { item ->
+                            UpcomingItemRow(item)
+                        }
+                    }
+                }
+            }
+        }
+
+        // Tareas por prioridad
+        item {
+            DashboardCard(
+                title = "Tareas por prioridad",
+                icon = Icons.Outlined.Flag,
+                iconTint = Color(0xFFFF5252),
+                onClick = onNavigateToTasks
+            ) {
+                PriorityDistribution(
+                    high = state.highPriorityCount,
+                    medium = state.mediumPriorityCount,
+                    low = state.lowPriorityCount
+                )
+            }
+        }
+
+        // Estado de Classroom
+        item {
+            DashboardCard(
+                title = "Estado de Classroom",
+                icon = Icons.Outlined.School,
+                iconTint = Color(0xFF388E3C),
+                onClick = onNavigateToClassroom
+            ) {
+                if (state.activeCourses.isEmpty()) {
+                    Text(
+                        text = "No hay cursos activos",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                } else {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        state.activeCourses.forEach { course ->
+                            CourseRow(course.name, course.pendingCount)
+                        }
+                    }
+                }
+            }
+        }
+
+        item { Spacer(modifier = Modifier.height(8.dp)) }
+    }
+}
+
+@Composable
+private fun SummarySection(
+    pendingCount: Int,
+    completedCount: Int,
+    dueSoonCount: Int,
+    onNavigateToTasks: () -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        SummaryCounter(
+            count = pendingCount,
+            label = "Pendientes",
+            icon = Icons.Outlined.Pending,
+            color = Color(0xFFFFA726),
+            modifier = Modifier.weight(1f),
+            onClick = onNavigateToTasks
+        )
+        SummaryCounter(
+            count = completedCount,
+            label = "Completadas",
+            icon = Icons.Outlined.CheckCircle,
+            color = Color(0xFF4CAF50),
+            modifier = Modifier.weight(1f),
+            onClick = onNavigateToTasks
+        )
+        SummaryCounter(
+            count = dueSoonCount,
+            label = "Por vencer",
+            icon = Icons.Outlined.Schedule,
+            color = Color(0xFFFF5252),
+            modifier = Modifier.weight(1f),
+            onClick = onNavigateToTasks
+        )
+    }
+}
+
+@Composable
+private fun SummaryCounter(
+    count: Int,
+    label: String,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    color: Color,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {}
+) {
+    DashboardCard(
+        title = "",
+        icon = icon,
+        iconTint = color,
+        modifier = modifier,
+        onClick = onClick
+    ) {
+        Text(
+            text = "$count",
+            style = MaterialTheme.typography.headlineMedium,
+            fontWeight = FontWeight.Bold,
+            color = color
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun UpcomingItemRow(item: UpcomingItem) {
+    val dateFormatter = DateTimeFormatter.ofPattern("dd MMM, HH:mm")
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = if (item.isClassroom) Icons.Outlined.School else Icons.Outlined.Assignment,
+            contentDescription = null,
+            modifier = Modifier.size(18.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = item.title,
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1
+            )
+            if (item.courseName != null) {
+                Text(
+                    text = item.courseName,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            }
+        }
+        if (item.dueDate != null) {
+            Text(
+                text = item.dueDate.format(dateFormatter),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun PriorityDistribution(high: Int, medium: Int, low: Int) {
+    val total = (high + medium + low).coerceAtLeast(1)
+
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        PriorityRow("Alta", high, total, Color(0xFFFF5252))
+        PriorityRow("Media", medium, total, Color(0xFFFFA726))
+        PriorityRow("Baja", low, total, Color(0xFF4CAF50))
+    }
+}
+
+@Composable
+private fun PriorityRow(label: String, count: Int, total: Int, color: Color) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.width(48.dp)
+        )
+        LinearProgressIndicator(
+            progress = { count.toFloat() / total },
+            modifier = Modifier
+                .weight(1f)
+                .height(8.dp)
+                .clip(RoundedCornerShape(4.dp)),
+            color = color,
+            trackColor = color.copy(alpha = 0.15f)
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(
+            text = "$count",
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = FontWeight.Bold
+        )
+    }
+}
+
+@Composable
+private fun CourseRow(name: String, pendingCount: Int) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = name,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.weight(1f),
+            maxLines = 1
+        )
+        Box(
+            modifier = Modifier
+                .background(
+                    color = MaterialTheme.colorScheme.primaryContainer,
+                    shape = RoundedCornerShape(12.dp)
+                )
+                .padding(horizontal = 10.dp, vertical = 4.dp)
+        ) {
+            Text(
+                text = "$pendingCount pendientes",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onPrimaryContainer
+            )
+        }
+    }
+}

--- a/android-app/app/src/main/java/com/agentasker/features/dashboard/presentation/screens/DashboardScreen.kt
+++ b/android-app/app/src/main/java/com/agentasker/features/dashboard/presentation/screens/DashboardScreen.kt
@@ -1,5 +1,6 @@
 package com.agentasker.features.dashboard.presentation.screens
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -13,10 +14,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Assignment
+import androidx.compose.material.icons.automirrored.outlined.Assignment
 import androidx.compose.material.icons.outlined.CalendarToday
 import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.Flag
@@ -252,6 +252,7 @@ private fun SummaryCounter(
     }
 }
 
+@SuppressLint("NewApi")
 @Composable
 private fun UpcomingItemRow(item: UpcomingItem) {
     val dateFormatter = DateTimeFormatter.ofPattern("dd MMM, HH:mm")
@@ -261,7 +262,7 @@ private fun UpcomingItemRow(item: UpcomingItem) {
         verticalAlignment = Alignment.CenterVertically
     ) {
         Icon(
-            imageVector = if (item.isClassroom) Icons.Outlined.School else Icons.Outlined.Assignment,
+            imageVector = if (item.isClassroom) Icons.Outlined.School else Icons.AutoMirrored.Outlined.Assignment,
             contentDescription = null,
             modifier = Modifier.size(18.dp),
             tint = MaterialTheme.colorScheme.onSurfaceVariant

--- a/android-app/app/src/main/java/com/agentasker/features/dashboard/presentation/viewmodel/DashboardViewModel.kt
+++ b/android-app/app/src/main/java/com/agentasker/features/dashboard/presentation/viewmodel/DashboardViewModel.kt
@@ -1,0 +1,143 @@
+package com.agentasker.features.dashboard.presentation.viewmodel
+
+import android.annotation.SuppressLint
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.agentasker.features.classroom.domain.entities.ClassroomTask
+import com.agentasker.features.classroom.domain.entities.SubmissionState
+import com.agentasker.features.classroom.domain.usecases.GetClassroomTasksUseCase
+import com.agentasker.features.tasks.domain.entities.Task
+import com.agentasker.features.tasks.domain.usecases.GetTasksUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.time.LocalDateTime
+import javax.inject.Inject
+
+data class CourseInfo(
+    val name: String,
+    val pendingCount: Int
+)
+
+data class UpcomingItem(
+    val title: String,
+    val courseName: String?,
+    val dueDate: LocalDateTime?,
+    val isClassroom: Boolean
+)
+
+sealed interface DashboardUiState {
+    object Loading : DashboardUiState
+    data class Success(
+        val pendingCount: Int,
+        val completedCount: Int,
+        val dueSoonCount: Int,
+        val upcomingDeadlines: List<UpcomingItem>,
+        val highPriorityCount: Int,
+        val mediumPriorityCount: Int,
+        val lowPriorityCount: Int,
+        val activeCourses: List<CourseInfo>
+    ) : DashboardUiState
+    data class Error(val message: String) : DashboardUiState
+}
+
+@HiltViewModel
+class DashboardViewModel @Inject constructor(
+    private val getTasksUseCase: GetTasksUseCase,
+    private val getClassroomTasksUseCase: GetClassroomTasksUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<DashboardUiState>(DashboardUiState.Loading)
+    val uiState: StateFlow<DashboardUiState> = _uiState.asStateFlow()
+
+    init {
+        loadDashboard()
+    }
+
+    fun refresh() {
+        loadDashboard()
+    }
+
+    private fun loadDashboard() {
+        viewModelScope.launch {
+            _uiState.value = DashboardUiState.Loading
+            try {
+                getTasksUseCase.refresh()
+            } catch (_: Exception) { }
+
+            getTasksUseCase().collect { tasks ->
+                val classroomTasks = try {
+                    getClassroomTasksUseCase().getOrDefault(emptyList())
+                } catch (_: Exception) {
+                    emptyList()
+                }
+                _uiState.value = buildSuccessState(tasks, classroomTasks)
+            }
+        }
+    }
+
+    @SuppressLint("NewApi")
+    private fun buildSuccessState(
+        tasks: List<Task>,
+        classroomTasks: List<ClassroomTask>
+    ): DashboardUiState.Success {
+        val now = LocalDateTime.now()
+        val threeDaysFromNow = now.plusDays(3)
+
+        val pendingClassroom = classroomTasks.filter {
+            it.submissionState != SubmissionState.TURNED_IN
+        }
+
+        val upcomingItems = mutableListOf<UpcomingItem>()
+
+        classroomTasks.forEach { ct ->
+            upcomingItems.add(
+                UpcomingItem(
+                    title = ct.title,
+                    courseName = ct.courseName,
+                    dueDate = ct.dueDate,
+                    isClassroom = true
+                )
+            )
+        }
+
+        tasks.forEach { t ->
+            upcomingItems.add(
+                UpcomingItem(
+                    title = t.title,
+                    courseName = null,
+                    dueDate = null,
+                    isClassroom = false
+                )
+            )
+        }
+
+        val sortedUpcoming = upcomingItems
+            .sortedWith(compareBy(nullsLast()) { it.dueDate })
+            .take(5)
+
+        val dueSoonCount = classroomTasks.count { ct ->
+            ct.dueDate != null &&
+                ct.dueDate.isAfter(now) &&
+                ct.dueDate.isBefore(threeDaysFromNow) &&
+                ct.submissionState != SubmissionState.TURNED_IN
+        }
+
+        val activeCourses = pendingClassroom
+            .groupBy { it.courseName }
+            .map { (name, courseTasks) -> CourseInfo(name, courseTasks.size) }
+
+        return DashboardUiState.Success(
+            pendingCount = tasks.size + pendingClassroom.size,
+            completedCount = classroomTasks.count { it.submissionState == SubmissionState.TURNED_IN },
+            dueSoonCount = dueSoonCount,
+            upcomingDeadlines = sortedUpcoming,
+            highPriorityCount = tasks.count { it.priority.lowercase() == "high" },
+            mediumPriorityCount = tasks.count { it.priority.lowercase() == "medium" },
+            lowPriorityCount = tasks.count { it.priority.lowercase() == "low" },
+            activeCourses = activeCourses
+        )
+    }
+}


### PR DESCRIPTION
## Resumen

- Nueva pantalla **Dashboard** como home post-login que unifica tareas propias y de Google Classroom en una vista consolidada (Feature 03 — Requerimiento F)
- `DashboardViewModel` combina datos de `GetTasksUseCase` y `GetClassroomTasksUseCase` con estado reactivo via `StateFlow`
- Secciones del Dashboard: resumen rápido (pendientes, completadas, por vencer), próximas entregas, tareas por prioridad y estado de Classroom
- Componente `DashboardCard` reutilizable para todas las tarjetas del dashboard
- Ruta `Screen.Dashboard` agregada a la navegación como pantalla inicial post-login
- Bottom navigation bar con: Dashboard, Tasks, Classroom
- Cada tarjeta navega a la sección correspondiente al hacer tap

## Archivos modificados

| Archivo | Cambio |
|---------|--------|
| `features/dashboard/presentation/screens/DashboardScreen.kt` | **Nuevo** — Pantalla principal con secciones: resumen, próximas entregas, prioridad y Classroom |
| `features/dashboard/presentation/viewmodel/DashboardViewModel.kt` | **Nuevo** — ViewModel con Hilt, combina tareas locales + Classroom, expone `DashboardUiState` |
| `features/dashboard/presentation/components/DashboardCard.kt` | **Nuevo** — Composable reutilizable para tarjetas del dashboard |
| `core/navigation/Screen.kt` | Agregada ruta `Screen.Dashboard` |
| `core/navigation/NavigatorWrapper.kt` | Dashboard como destino inicial, integración de bottom navigation bar |
| `MainActivity.kt` | Configuración de Dashboard como pantalla post-login con bottom navigation |