### PR TITLE
[add]: Hardware: Monitor de conectividad

### DIFF
--- a/android-app/app/src/main/java/com/agentasker/MainActivity.kt
+++ b/android-app/app/src/main/java/com/agentasker/MainActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Dashboard
@@ -24,10 +25,11 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.agentasker.core.navigation.NavigatorWrapper
 import com.agentasker.core.navigation.Screen
+import com.agentasker.core.network.NetworkMonitor
+import com.agentasker.core.ui.components.OfflineBanner
 import com.agentasker.core.ui.theme.AgenTaskerTheme
 import com.agentasker.features.classroom.data.services.ClassroomAuthService
 import com.agentasker.features.classroom.presentation.screens.ClassroomScreen
@@ -44,25 +46,36 @@ class MainActivity : ComponentActivity() {
     @Inject
     lateinit var classroomAuthService: ClassroomAuthService
 
+    @Inject
+    lateinit var networkMonitor: NetworkMonitor
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
         setContent {
             AgenTaskerTheme {
-                AgentTaskerApp(classroomAuthService = classroomAuthService)
+                AgentTaskerApp(
+                    classroomAuthService = classroomAuthService,
+                    networkMonitor = networkMonitor
+                )
             }
         }
     }
 }
 
 @Composable
-fun AgentTaskerApp(classroomAuthService: ClassroomAuthService) {
+fun AgentTaskerApp(
+    classroomAuthService: ClassroomAuthService,
+    networkMonitor: NetworkMonitor
+) {
     val navController = rememberNavController()
     val navigatorWrapper = remember { NavigatorWrapper(navController) }
 
     val loginViewModel: LoginViewModel = hiltViewModel()
     val loginUiState by loginViewModel.uiState.collectAsStateWithLifecycle()
+
+    val isOnline by networkMonitor.isOnline.collectAsStateWithLifecycle(initialValue = true)
 
     val startDestination = if (loginUiState.isAuthenticated) {
         Screen.Dashboard.route
@@ -84,7 +97,7 @@ fun AgentTaskerApp(classroomAuthService: ClassroomAuthService) {
         }
 
         composable(Screen.Dashboard.route) {
-            MainScaffold(navController = navController, currentRoute = Screen.Dashboard.route) {
+            MainScaffold(navController = navController, currentRoute = Screen.Dashboard.route, isOffline = !isOnline) {
                 DashboardScreen(
                     onNavigateToTasks = {
                         navController.navigate(Screen.Tasks.route) {
@@ -105,13 +118,13 @@ fun AgentTaskerApp(classroomAuthService: ClassroomAuthService) {
         }
 
         composable(Screen.Tasks.route) {
-            MainScaffold(navController = navController, currentRoute = Screen.Tasks.route) {
+            MainScaffold(navController = navController, currentRoute = Screen.Tasks.route, isOffline = !isOnline) {
                 TaskScreen()
             }
         }
 
         composable(Screen.Classroom.route) {
-            MainScaffold(navController = navController, currentRoute = Screen.Classroom.route) {
+            MainScaffold(navController = navController, currentRoute = Screen.Classroom.route, isOffline = !isOnline) {
                 ClassroomScreen(classroomAuthService = classroomAuthService)
             }
         }
@@ -122,6 +135,7 @@ fun AgentTaskerApp(classroomAuthService: ClassroomAuthService) {
 fun MainScaffold(
     navController: NavHostController,
     currentRoute: String,
+    isOffline: Boolean = false,
     content: @Composable () -> Unit
 ) {
     Scaffold(
@@ -171,8 +185,11 @@ fun MainScaffold(
             }
         }
     ) { innerPadding ->
-        Box(modifier = Modifier.padding(innerPadding)) {
-            content()
+        Column(modifier = Modifier.padding(innerPadding)) {
+            OfflineBanner(isOffline = isOffline)
+            Box(modifier = Modifier.weight(1f)) {
+                content()
+            }
         }
     }
 }

--- a/android-app/app/src/main/java/com/agentasker/core/di/NetworkModule.kt
+++ b/android-app/app/src/main/java/com/agentasker/core/di/NetworkModule.kt
@@ -1,12 +1,16 @@
 package com.agentasker.core.di
 
+import android.content.Context
 import com.agentasker.BuildConfig
 import com.agentasker.core.network.AgentTaskerApi
 import com.agentasker.core.network.AuthInterceptor
+import com.agentasker.core.network.ConnectivityManagerNetworkMonitor
+import com.agentasker.core.network.NetworkMonitor
 import com.agentasker.features.login.data.datasources.local.SecureDataStoreTokenStorage
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
@@ -49,5 +53,11 @@ object NetworkModule {
     @Singleton
     fun provideAgentTaskerApi(retrofit: Retrofit): AgentTaskerApi {
         return retrofit.create(AgentTaskerApi::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideNetworkMonitor(@ApplicationContext context: Context): NetworkMonitor {
+        return ConnectivityManagerNetworkMonitor(context)
     }
 }

--- a/android-app/app/src/main/java/com/agentasker/core/network/ConnectivityManagerNetworkMonitor.kt
+++ b/android-app/app/src/main/java/com/agentasker/core/network/ConnectivityManagerNetworkMonitor.kt
@@ -1,0 +1,48 @@
+package com.agentasker.core.network
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ConnectivityManagerNetworkMonitor @Inject constructor(
+    @ApplicationContext private val context: Context
+) : NetworkMonitor {
+
+    private val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE)
+        as ConnectivityManager
+
+    override val isOnline: Flow<Boolean> = callbackFlow {
+        val callback = object : ConnectivityManager.NetworkCallback() {
+            override fun onAvailable(network: Network) {
+                trySend(true)
+            }
+
+            override fun onLost(network: Network) {
+                trySend(false)
+            }
+        }
+
+        val request = NetworkRequest.Builder()
+            .addCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            .build()
+
+        connectivityManager.registerNetworkCallback(request, callback)
+
+        // Estado inicial
+        val currentNetwork = connectivityManager.activeNetwork
+        val isConnected = connectivityManager.getNetworkCapabilities(currentNetwork)
+            ?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
+        trySend(isConnected)
+
+        awaitClose { connectivityManager.unregisterNetworkCallback(callback) }
+    }
+}

--- a/android-app/app/src/main/java/com/agentasker/core/network/NetworkMonitor.kt
+++ b/android-app/app/src/main/java/com/agentasker/core/network/NetworkMonitor.kt
@@ -1,0 +1,7 @@
+package com.agentasker.core.network
+
+import kotlinx.coroutines.flow.Flow
+
+interface NetworkMonitor {
+    val isOnline: Flow<Boolean>
+}

--- a/android-app/app/src/main/java/com/agentasker/core/ui/components/OfflineBanner.kt
+++ b/android-app/app/src/main/java/com/agentasker/core/ui/components/OfflineBanner.kt
@@ -1,0 +1,51 @@
+package com.agentasker.core.ui.components
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.WifiOff
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun OfflineBanner(isOffline: Boolean) {
+    AnimatedVisibility(
+        visible = isOffline,
+        enter = expandVertically(),
+        exit = shrinkVertically()
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.errorContainer)
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.Default.WifiOff,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp),
+                tint = MaterialTheme.colorScheme.onErrorContainer
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = "Sin conexión a internet",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onErrorContainer
+            )
+        }
+    }
+}

--- a/android-app/app/src/main/java/com/agentasker/features/tasks/data/repositories/TaskRepositoryImpl.kt
+++ b/android-app/app/src/main/java/com/agentasker/features/tasks/data/repositories/TaskRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.agentasker.features.tasks.data.repositories
 
 import com.agentasker.core.network.AgentTaskerApi
+import com.agentasker.core.network.NetworkMonitor
 import com.agentasker.features.tasks.data.datasources.local.dao.TaskDao
 import com.agentasker.features.tasks.data.datasources.local.entities.TaskEntity
 import com.agentasker.features.tasks.data.datasources.local.mapper.toDomain
@@ -17,14 +18,18 @@ import javax.inject.Inject
 
 class TaskRepositoryImpl @Inject constructor(
     private val api: AgentTaskerApi,
-    private val taskDao: TaskDao
+    private val taskDao: TaskDao,
+    private val networkMonitor: NetworkMonitor
 ) : TaskRepository {
+
+    private suspend fun isOnline(): Boolean = networkMonitor.isOnline.first()
 
     override fun observeTasks(): Flow<List<Task>> {
         return taskDao.getAllTasks().map { entities -> entities.toDomain() }
     }
 
     override suspend fun refreshTasks() {
+        if (!isOnline()) return
         try {
             val remoteTasks = api.getTasks()
             taskDao.upsertTasks(remoteTasks.toEntities(isSynced = true))
@@ -39,10 +44,16 @@ class TaskRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getTaskById(id: String): Task {
-        val response = api.getTaskById(id.toInt())
-        val entity = response.toEntity(isSynced = true)
-        taskDao.upsertTask(entity)
-        return entity.toDomain()
+        if (isOnline()) {
+            try {
+                val response = api.getTaskById(id.toInt())
+                val entity = response.toEntity(isSynced = true)
+                taskDao.upsertTask(entity)
+                return entity.toDomain()
+            } catch (_: Exception) { }
+        }
+        return taskDao.getTaskById(id).first()?.toDomain()
+            ?: throw Exception("Tarea no encontrada")
     }
 
     override suspend fun createTask(title: String, description: String, priority: String): Task {
@@ -51,22 +62,23 @@ class TaskRepositoryImpl @Inject constructor(
             description = description,
             priority = priority
         )
-        return try {
-            val response = api.createTask(request)
-            val entity = response.toEntity(isSynced = true)
-            taskDao.upsertTask(entity)
-            entity.toDomain()
-        } catch (e: Exception) {
-            val localEntity = TaskEntity(
-                id = "local_${System.currentTimeMillis()}",
-                title = title,
-                description = description,
-                priority = priority,
-                isSynced = false
-            )
-            taskDao.upsertTask(localEntity)
-            localEntity.toDomain()
+        if (isOnline()) {
+            try {
+                val response = api.createTask(request)
+                val entity = response.toEntity(isSynced = true)
+                taskDao.upsertTask(entity)
+                return entity.toDomain()
+            } catch (_: Exception) { }
         }
+        val localEntity = TaskEntity(
+            id = "local_${System.currentTimeMillis()}",
+            title = title,
+            description = description,
+            priority = priority,
+            isSynced = false
+        )
+        taskDao.upsertTask(localEntity)
+        return localEntity.toDomain()
     }
 
     override suspend fun updateTask(
@@ -80,27 +92,29 @@ class TaskRepositoryImpl @Inject constructor(
             description = description,
             priority = priority
         )
-        return try {
-            val response = api.updateTask(id.toInt(), request)
-            val entity = response.toEntity(isSynced = true)
-            taskDao.upsertTask(entity)
-            entity.toDomain()
-        } catch (e: Exception) {
-            val current = taskDao.getTaskById(id).first()
-                ?: throw e
-            val updated = current.copy(
-                title = title ?: current.title,
-                description = description ?: current.description,
-                priority = priority ?: current.priority,
-                isSynced = false
-            )
-            taskDao.upsertTask(updated)
-            updated.toDomain()
+        if (isOnline()) {
+            try {
+                val response = api.updateTask(id.toInt(), request)
+                val entity = response.toEntity(isSynced = true)
+                taskDao.upsertTask(entity)
+                return entity.toDomain()
+            } catch (_: Exception) { }
         }
+        val current = taskDao.getTaskById(id).first()
+            ?: throw Exception("Tarea no encontrada")
+        val updated = current.copy(
+            title = title ?: current.title,
+            description = description ?: current.description,
+            priority = priority ?: current.priority,
+            isSynced = false
+        )
+        taskDao.upsertTask(updated)
+        return updated.toDomain()
     }
 
     override suspend fun deleteTask(id: String) {
         taskDao.deleteTaskById(id)
+        if (!isOnline()) return
         try {
             api.deleteTask(id.toInt())
         } catch (_: Exception) {


### PR DESCRIPTION
## Resumen

- Implementación de monitoreo de conectividad de red usando `ConnectivityManager` via `applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE)` (Hardware #1 — Requerimiento E)
- Nueva interface `NetworkMonitor` con `Flow<Boolean>` reactivo para observar estado de red en tiempo real
- Implementación `ConnectivityManagerNetworkMonitor` como `@Singleton` con `callbackFlow` y `NetworkCallback` para detectar `onAvailable`/`onLost`
- Banner offline animado (`OfflineBanner`) visible en las 3 pantallas principales (Dashboard, Tasks, Classroom) usando `AnimatedVisibility`
- `TaskRepositoryImpl` usa `NetworkMonitor` para skip de llamadas API cuando no hay red, evitando timeouts innecesarios y yendo directo a caché Room
- Permiso `ACCESS_NETWORK_STATE` ya existente en el manifest — no requiere cambios

## Archivos creados

| Archivo | Descripción |
|---------|-------------|
| `core/network/NetworkMonitor.kt` | **Nuevo** — Interface con `val isOnline: Flow<Boolean>` |
| `core/network/ConnectivityManagerNetworkMonitor.kt` | **Nuevo** — `@Singleton`: `callbackFlow` con `NetworkCallback.onAvailable`/`onLost`, estado inicial via `activeNetwork` + `NET_CAPABILITY_INTERNET` |
| `core/ui/components/OfflineBanner.kt` | **Nuevo** — Composable: `AnimatedVisibility` + `Row` con icono `WifiOff` + "Sin conexión a internet" sobre `errorContainer` |

## Archivos modificados

| Archivo | Cambio |
|---------|--------|
| `core/di/NetworkModule.kt` | Agregado `provideNetworkMonitor(@ApplicationContext context)` que retorna `ConnectivityManagerNetworkMonitor` como `NetworkMonitor` |
| `features/tasks/data/repositories/TaskRepositoryImpl.kt` | Inyecta `NetworkMonitor`; helper `isOnline()` con `.first()`; skip API en `refreshTasks()`, `createTask()`, `updateTask()`, `deleteTask()` si offline; `getTaskById()` fallback a Room si offline |
| `MainActivity.kt` | Inyecta `NetworkMonitor` en Activity; collecta `isOnline` con `collectAsStateWithLifecycle`; pasa `isOffline` a `MainScaffold`; `Column` con `OfflineBanner` + content en las 3 pantallas |
